### PR TITLE
Updating Homebrew install path

### DIFF
--- a/homebrew/install.sh
+++ b/homebrew/install.sh
@@ -9,7 +9,7 @@
 # Check for Homebrew
 if test ! "$(which brew)"; then
   echo "  Installing Homebrew for you."
-  ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
+  ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 fi
 
 brew update


### PR DESCRIPTION
The previous URL returned this message:

```
Whoops, the Homebrew installer has moved! Please instead run:

ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"

Also, please ask wherever you got this link from to update it to the above.
Thanks!
```

:+1: 
