### PR TITLE
new required flag for Homebrew

### DIFF
--- a/homebrew/aliases.zsh
+++ b/homebrew/aliases.zsh
@@ -1,7 +1,7 @@
 #!/bin/zsh
 brewbump() {
   brew update
-  brew upgrade
+  brew upgrade --all
   brew cleanup
   brew cask cleanup
 }


### PR DESCRIPTION
`brew upgrade` will change soon, to required the flag `--all` for upgrades,

easy update to avoid the warning below, cc @caarlos0 

![Homebrew Upgrade](https://dl.dropboxusercontent.com/s/z6idwtyk1dk07ii/Screen%20Shot%202015-04-28%20at%209.15.53%20AM.png)
