### PR TITLE
Added mkdir -p for GOPATH/src/github.com

### DIFF
--- a/golang/path.zsh
+++ b/golang/path.zsh
@@ -1,5 +1,5 @@
 #!/bin/sh
 export GOPATH="$PROJECTS/Go"
 [ ! -d "$GOPATH" ] &&  mkdir -p "$GOPATH"/bin
-
+[ ! -d "$GOPATH/src/github.com/" ] && mkdir -p "$GOPATH/src/github.com/"
 export PATH="$GOPATH/bin:$PATH"


### PR DESCRIPTION
With that, after dotfiles is instaled, the `g` alias will work out of
the box. Right now it won't because the src/github.com folder might not
exist yet.
