### PR TITLE
Added vip command

### DIFF
--- a/bin/vip
+++ b/bin/vip
@@ -1,0 +1,5 @@
+#!/bin/sh
+# open files from xargs in tabs and without messing up yout tty.
+# example usage: git grep -c bash | cut -f1 -d':' | xargs vip
+exec vim < /dev/tty -p "$@"
+


### PR DESCRIPTION
If you `| xargs vim` something, your tty will be messed up.

This command basically fixes that and also opens all files in tabs
inside vim.

Example usage:

``` sh
$ git grep -c bash | cut -f1 -d':' | xargs vip # opens all files containg the string "bash"
```
- http://stackoverflow.com/questions/24281304/vim-input-is-not-from-a-terminal
- http://superuser.com/questions/336016/invoking-vi-through-find-xargs-breaks-my-terminal-why
- http://vim.1045645.n5.nabble.com/Vim-Warning-Input-is-not-from-a-terminal-td4332375.html
- http://unix.stackexchange.com/questions/77395/grep-l-xargs-vim-generates-a-warning-why
