### PR TITLE
Fixed remains of dot rename to dot_update

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ bash -c "$(wget -O - https://raw.githubusercontent.com/caarlos0/dotfiles/master/
 This will symlink the appropriate files in `.dotfiles` to your home directory.
 Everything is configured and tweaked within `~/.dotfiles`.
 
-`dot` is a simple script that installs some dependencies, sets sane OS X
-defaults, and so on. Tweak this script, and occasionally run `dot` from
+`dot_update` is a simple script that installs some dependencies, sets sane OS X
+defaults, and so on. Tweak this script, and occasionally run `dot_update` from
 time to time to keep your environment fresh and up-to-date. You can find
 this script in `bin/`.
 

--- a/bin/dot_update
+++ b/bin/dot_update
@@ -1,8 +1,8 @@
 #!/bin/zsh
 #
-# dot
+# dot_update
 #
-# `dot` handles installation, updates, things like that. Run it periodically
+# `dot_update` handles installation, updates, things like that. Run it periodically
 # to make sure you're on the latest and greatest.
 main() {
   cd ~/.dotfiles

--- a/bin/dot_update
+++ b/bin/dot_update
@@ -26,7 +26,8 @@ main() {
   ./homebrew/install.sh
 
   # find the installers and run them iteratively
-  find . -name install.sh | egrep -v "homebrew|build" | while read installer; do
+  find . -name install.sh | egrep -v "homebrew|build" | while read installer
+  do
     echo "$ ${installer}..."
     sh -c "$installer" >> /tmp/dotfiles-dot
   done

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -125,7 +125,7 @@ setup_gitconfig
 install_dotfiles
 
 info "installing dependencies"
-if ./bin/dot > /tmp/dotfiles-dot 2>&1 ; then
+if ./bin/dot_update > /tmp/dotfiles-update 2>&1 ; then
   success "dependencies installed"
 else
   fail "error installing dependencies"


### PR DESCRIPTION
I end up broking some stuff when I renamed `dot` to `dot_update` because
I completely forgot to change the usages of it in other scripts (and
    README).

This fixes that.
