### PR TITLE
fixed editorconfig for xml and java

### DIFF
--- a/editorconfig/editorconfig.symlink
+++ b/editorconfig/editorconfig.symlink
@@ -13,6 +13,8 @@ insert_final_newline = true
 max_line_length = 80
 trim_trailing_whitespace = true
 
+[*.xml]
+indent_style = tab
+
 [*.java]
 indent_style = tab
-indent_size = 4


### PR DESCRIPTION
- java had 2 indent settings
- xml had no indent settings at all
