### PR TITLE
Fixed CTRL+L cleaning too much stuff

### DIFF
--- a/antibody/bundles.txt
+++ b/antibody/bundles.txt
@@ -4,5 +4,3 @@ mafredri/zsh-async
 caarlos0/zsh-git-sync
 zsh-users/zsh-completions
 caarlos0/zsh-open-github-pr
-zsh-users/zsh-syntax-highlighting
-zsh-users/zsh-history-substring-search

--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -3,7 +3,7 @@ PURE_CMD_MAX_EXEC_TIME=1
 PURE_GIT_PULL=0
 antibody bundle sindresorhus/pure
 
-# this two guys **MUST** be load last.
+# these two guys **MUST** be load last.
 antibody bundle <<EOF
 zsh-users/zsh-syntax-highlighting
 zsh-users/zsh-history-substring-search

--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -2,3 +2,9 @@
 PURE_CMD_MAX_EXEC_TIME=1
 PURE_GIT_PULL=0
 antibody bundle sindresorhus/pure
+
+# this two guys **MUST** be load last.
+antibody bundle <<EOF
+zsh-users/zsh-syntax-highlighting
+zsh-users/zsh-history-substring-search
+EOF


### PR DESCRIPTION
This makes the `CTRL+L`/`clear` behavior go from

![image](https://cloud.githubusercontent.com/assets/245435/12295337/a8fde108-b9e7-11e5-9430-d7d1fabdc9ab.png)

to

![image](https://cloud.githubusercontent.com/assets/245435/12295343/afeda0fc-b9e7-11e5-8d17-7683da9867b0.png)

Yeah, way better.
