### PR TITLE
linuxbrew path fix on clean machine

### DIFF
--- a/homebrew/install.sh
+++ b/homebrew/install.sh
@@ -14,7 +14,7 @@ if test ! "$(which brew)"; then
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
   else
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/linuxbrew/go/install)"
-    source "$ZSH/homebrew/path.zsh"
+    . "$ZSH/homebrew/path.zsh"
   fi
 fi
 

--- a/homebrew/install.sh
+++ b/homebrew/install.sh
@@ -14,6 +14,7 @@ if test ! "$(which brew)"; then
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
   else
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/linuxbrew/go/install)"
+    source "$ZSH/homebrew/path.zsh"
   fi
 fi
 


### PR DESCRIPTION
Running script/bootstrap on an empty linux machine will cause trouble
with linuxbrew, because it is not in the path yet.

This might fix that.

cc/ @victorbogo
