### PR TITLE
replaced tunnelblick with viscosity

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -53,8 +53,8 @@ if RUBY_PLATFORM =~ /darwin/
   cask 'telegram'
   cask 'the-unarchiver'
   cask 'transmission'
-  cask 'tunnelblick'
   cask 'virtualbox'
+  cask 'viscosity'
   cask 'vlc'
 
   # https://github.com/sindresorhus/quick-look-plugins


### PR DESCRIPTION
tunnelblick seems not to work in latest OSX.

Payed for viscosity and it is working like a bliss.
