### PR TITLE
Sourcing homebrew/path.zsh on dot_update

### DIFF
--- a/bin/dot_update
+++ b/bin/dot_update
@@ -12,6 +12,7 @@ export ZSH="$HOME/.dotfiles"
 
 # Install homebrew
 "$ZSH/homebrew/install.sh" 2>&1
+. "$ZSH/homebrew/path.zsh"
 
 # Upgrade homebrew
 echo "› brew update"

--- a/golang/path.zsh
+++ b/golang/path.zsh
@@ -1,5 +1,5 @@
 #!/bin/sh
 export GOPATH="$PROJECTS/Go"
-[ ! -d "$GOPATH" ] &&  mkdir -p "$GOPATH"/bin
+[ ! -d "$GOPATH" ] &&  mkdir -p "$GOPATH/bin"
 [ ! -d "$GOPATH/src/github.com/" ] && mkdir -p "$GOPATH/src/github.com/"
 export PATH="$GOPATH/bin:$PATH"

--- a/homebrew/install.sh
+++ b/homebrew/install.sh
@@ -14,7 +14,6 @@ if test ! "$(which brew)"; then
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
   else
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/linuxbrew/go/install)"
-    . "$ZSH/homebrew/path.zsh"
   fi
 fi
 


### PR DESCRIPTION
We first make sure that homebrew is installed, but we were never
checking the path was right.
- Fixes #138
