### PR TITLE
Delete .mention-bot

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,3 +1,0 @@
-{
-  "userBlacklist": ["holman", "rcarver", "ncolton"]
-}


### PR DESCRIPTION
mention-bot will mention people from the original fork most of the time, so, why bother...
