### PR TITLE
atom stuff / text replacer

### DIFF
--- a/atom.symlink/config.cson
+++ b/atom.symlink/config.cson
@@ -1,6 +1,4 @@
 "*":
-  "atom-beautify":
-    _analyticsUserId: "ffd4ab29-bf27-43d2-94bd-694aa1f6562c"
   core:
     autoHideMenuBar: true
     disabledPackages: [

--- a/atom.symlink/config.cson
+++ b/atom.symlink/config.cson
@@ -1,24 +1,26 @@
 "*":
-  editor:
-    invisibles: {}
-    fontSize: 15
-    showIndentGuide: true
-    showInvisibles: true
-    scrollPastEnd: true
-    fontFamily: "Hack"
+  "atom-beautify":
+    _analyticsUserId: "ffd4ab29-bf27-43d2-94bd-694aa1f6562c"
   core:
-    hideGitIgnoredFiles: true
     autoHideMenuBar: true
-    projectHome: "~/Code/"
     disabledPackages: [
       "metrics"
       "exception-reporting"
     ]
-  welcome:
-    showOnStartup: false
-  linter: {}
+    hideGitIgnoredFiles: true
+    projectHome: "~/Code/"
+  editor:
+    fontFamily: "Hack"
+    fontSize: 15
+    invisibles: {}
+    scrollPastEnd: true
+    showIndentGuide: true
+    showInvisibles: true
   "go-plus":
     goPath: "~/Code/Go"
   "go-rename": {}
+  linter: {}
   "tree-view":
     hideVcsIgnoredFiles: true
+  welcome:
+    showOnStartup: false

--- a/atom.symlink/install.sh
+++ b/atom.symlink/install.sh
@@ -3,6 +3,7 @@ if test ! "$(which apm)"; then
   return 0
 fi
 apm install \
+  atom-wrap-in-tag \
   editorconfig \
   language-docker \
   language-diff \

--- a/osx/set-defaults.sh
+++ b/osx/set-defaults.sh
@@ -39,6 +39,8 @@ defaults write com.apple.dock wvous-bl-modifier -int 0
 # Disable transparency in the menu bar and elsewhere on Yosemite
 defaults write com.apple.universalaccess reduceTransparency -bool true
 
+# Enable text replacement almost everywhere
+defaults write -g WebAutomaticTextReplacementEnabled -bool true
 #
 # Finder
 #


### PR DESCRIPTION
Atom config format changed for some reason.

Also added atom-wrap-in-tag plugin.

Configured text replacer to work "everywhere"
