### PR TITLE
speeding it up a little more

### DIFF
--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -25,8 +25,13 @@ for file in ${${config_files:#*/path.zsh}:#*/completion.zsh}; do
   source "$file"
 done
 
-# initialize autocomplete here, otherwise functions won't be loaded
-autoload -U compinit && compinit
+autoload -Uz compinit
+if [ $(date +'%j') != $(stat -f '%Sm' -t '%j' ~/.zcompdump) ]; then
+  compinit
+else
+  compinit -C
+fi
+
 
 # load every completion after autocomplete loads
 for file in ${(M)config_files:#*/completion.zsh}; do


### PR DESCRIPTION
Now even faster:

``` console
~/.dotfiles more-speed
❯ for i in $(seq 1 10); do /usr/bin/time zsh -i -c exit; done
      0.28 real         0.13 user         0.14 sys
      0.26 real         0.12 user         0.14 sys
      0.25 real         0.12 user         0.14 sys
      0.23 real         0.11 user         0.12 sys
      0.25 real         0.12 user         0.13 sys
      0.23 real         0.11 user         0.13 sys
      0.23 real         0.11 user         0.12 sys
      0.24 real         0.11 user         0.13 sys
      0.26 real         0.13 user         0.14 sys
      0.26 real         0.12 user         0.14 sys
```

![image](https://cloud.githubusercontent.com/assets/245435/14413468/56555d32-ff51-11e5-90c7-de6d4a60bcd1.png)

refs #189 
