### PR TITLE
Wakatime

### DIFF
--- a/antibody/bundles.txt
+++ b/antibody/bundles.txt
@@ -1,9 +1,11 @@
+# note this is alphabetically sorted
 caarlos0/jvm
-Tarrasch/zsh-bd
-caarlos0/zsh-mkc
-mafredri/zsh-async
-caarlos0/zsh-git-sync
-zsh-users/zsh-completions
 caarlos0/zsh-add-upstream
-caarlos0/zsh-open-github-pr
 caarlos0/zsh-git-fetch-merge
+caarlos0/zsh-git-sync
+caarlos0/zsh-mkc
+caarlos0/zsh-open-github-pr
+mafredri/zsh-async
+Tarrasch/zsh-bd
+wbinglee/zsh-wakatime
+zsh-users/zsh-completions

--- a/atom.symlink/config.cson
+++ b/atom.symlink/config.cson
@@ -31,5 +31,7 @@
     hideVcsIgnoredFiles: true
   "unity-ui":
     showIcons: true
+  wakatime:
+    apikey: "Saved in your ~/.wakatime.cfg file"
   welcome:
     showOnStartup: false

--- a/atom.symlink/install.sh
+++ b/atom.symlink/install.sh
@@ -18,5 +18,6 @@ apm install \
   linter-ruby \
   native-ui \
   one-dark-syntax \
-  sort-lines
+  sort-lines \
+  wakatime
 apm remove metrics exception-reporting || true


### PR DESCRIPTION
For it to work, user will still need to `pip install wakatime` and configure `~/.wakatime.cfg`.

So, I don't think this will be a dealbreaker for those who don't want to use wakatime for any reason...
