### PR TITLE
Fix typo in git config command

### DIFF
--- a/git/install.sh
+++ b/git/install.sh
@@ -2,9 +2,9 @@
 
 # Don't ask ssh password all the time
 if [ "$(uname -s)" = "Darwin" ]; then
-  git config --global user.helper osxkeychain
+  git config --global credential.helper osxkeychain
 else
-  git config --global user.helper cache
+  git config --global credential.helper cache
 fi
 
 # better diffs


### PR DESCRIPTION
As best I can tell `user.helper` should be `credential.helper`.

See: https://git-scm.com/docs/gitcredentials and https://git-scm.com/docs/git-config
