### PR TITLE
Speed up Atom package installation script

### DIFF
--- a/atom.symlink/install.sh
+++ b/atom.symlink/install.sh
@@ -21,7 +21,9 @@ if test "$(which apm)"; then
     wakatime
   "
   for module in $modules; do
-    apm list | grep -q "$module" || apm install "$module"
+    if [[ ! -d "$HOME/.atom/packages/$module" ]]; then
+      apm install "$module"
+    fi
   done
 
   modules="
@@ -29,6 +31,8 @@ if test "$(which apm)"; then
     exception-reporting
   "
   for module in $modules; do
-    apm list | grep -q "$module" || apm remove "$module"
+    if [[ -d "$HOME/.atom/packages/$module" ]]; then
+      apm remove "$module"
+    fi
   done
 fi


### PR DESCRIPTION
This approach is significantly faster than running apm list and grepping to validate package installation.  It is also less prone to issues when packages have similar names.