### PR TITLE
fix: ruby 2+ is the default now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
-rvm:
-  - 2.0.0
 os:
   - linux
   - osx


### PR DESCRIPTION
dont need to force 2.0.0 (which is not even working on macos)