### PR TITLE
Ignore if zsh already set as default shell

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -107,6 +107,7 @@ fi
 
 zsh="$(find_zsh)"
 test -z "$TRAVIS_JOB_ID" &&
+	test "$(expr "$SHELL" : '.*/\(.*\)')" != "zsh" &&
 	which chsh >/dev/null 2>&1 &&
 	chsh -s "$zsh" &&
 	success "set $("$zsh" --version) at $zsh as default shell"


### PR DESCRIPTION
Avoid problems like this: https://askubuntu.com/questions/812420/chsh-always-asking-a-password-and-get-pam-authentication-failure/812426