### PR TITLE
fix(scripts): add directory for fonts explicitly and set positional to 1

### DIFF
--- a/fonts/install.sh
+++ b/fonts/install.sh
@@ -3,8 +3,8 @@ URL="https://github.com/ryanoasis/nerd-fonts/releases/download/v2.0.0/FiraCode.z
 
 install() {
 	curl -L -s -o /tmp/fura.zip "$URL"
-	unzip /tmp/fura.zip -d /tmp
-	cp /tmp/FiraCode/*.ttf "$2"
+	unzip /tmp/fura.zip -d /tmp/FiraCode
+	cp /tmp/FiraCode/*.ttf "$1"
 }
 
 if [ "$(uname -s)" = "Darwin" ]; then


### PR DESCRIPTION
install function is being called with 1 argument so "$1" should be used

potentially breaks install for macOS