### PR TITLE
Remove Deprecated Brew Cask Clean

### DIFF
--- a/homebrew/aliases.zsh
+++ b/homebrew/aliases.zsh
@@ -5,7 +5,6 @@ if which brew >/dev/null 2>&1; then
 		cleanup)
 			(cd "$(brew --repo)" && git prune && git gc)
 			command brew cleanup
-			command brew cask cleanup
 			command brew prune
 			rm -rf "$(brew --cache)"
 			;;


### PR DESCRIPTION
The Cask cleanup command is now deprecated, and will be removed next month. Regular cleanup should handle both, I'd assume.

As of this morning, I'm getting this message:

```
Warning: Calling `brew cask cleanup` is deprecated and will be disabled on 2018-09-30! Use `brew cleanup` instead
```